### PR TITLE
Remove relative links

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -2,6 +2,6 @@
 
 Things that got covered in the discord.
 
-[asset folder creation](./asset_folder_creation.md)
+[asset folder creation](https://github.com/chazlarson/Plex-Meta-Manager-Cookbook/blob/main/cookbook/asset_folder_creation.md)
 
-[general](./general.md)
+[general](https://github.com/chazlarson/Plex-Meta-Manager-Cookbook/blob/main/cookbook/general.md)

--- a/guides/README.md
+++ b/guides/README.md
@@ -1,6 +1,6 @@
 ## Articles:
 
-[Using positional vs non-positional overlays](positional-non-positional.md)
+[Using positional vs non-positional overlays](https://github.com/chazlarson/Plex-Meta-Manager-Cookbook/blob/main/guides/positional-non-positional.md)
 
 The plan is to convert some or all of these to Markdown; for now, here are links to the source Google Docs
 


### PR DESCRIPTION
The PMM wiki cant interpret the relative links correctly so changed them all to direct links 